### PR TITLE
Remove github.com/concourse/concourse

### DIFF
--- a/livereload.go
+++ b/livereload.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/concourse/concourse/src/github.com/gorilla/websocket"
+	"github.com/gorilla/websocket"
 	"github.com/fsnotify/fsnotify"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"


### PR DESCRIPTION
Not sure why this was done, but when I run `go get -v github.com/mattn/echo-livereload` it never finishes. 